### PR TITLE
Add build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           quarto render
 
       - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
+        # if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           clean: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: main
+  # to be able to trigger a manual build
+  workflow_dispatch:
+
+name: Render and deploy Book to GitHub
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+
+      - name: Render book to all format
+        # Add any command line argument needed
+        run: |
+          quarto render
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          clean: false
+          branch: gh-pages
+          folder: _site
+          single-commit: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           quarto render
 
       - name: Deploy to GitHub pages 🚀
-        # if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           clean: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,11 @@ jobs:
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
 
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
+      # - uses: r-lib/actions/setup-r@v2
+      #   with:
+      #     use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      # - uses: r-lib/actions/setup-r-dependencies@v2
 
       - name: Render book to all format
         # Add any command line argument needed

--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,6 @@ rsconnect/
 /.quarto/
 
 _book/
+_site/
 
 index_files/

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,5 +1,6 @@
 project:
   type: book
+  output-dir: _site
 
 book:
   title: "Odin-Monty Workshop"


### PR DESCRIPTION
Adds a workflow to build automatically; see it at https://mrc-ide.github.io/odin-monty-workshop-2025/

Please make the repo public so that this stays functional (private repos do not work well with github actions). The web page is itself public.